### PR TITLE
Changed TopSky D-area Colour

### DIFF
--- a/Plugins/TopSkySettings.txt
+++ b/Plugins/TopSkySettings.txt
@@ -13,8 +13,8 @@ Setup_COOPANS=0
 
 //---------- Colors ----------//
 
-Color_Active_Map_Type_5=198,174,58
-                                    //rgb(198,174,58)
+Color_Active_Map_Type_5=120,50,50
+                                    //rgb(120, 50, 50)
 Color_Active_RD_Infill_Map=90,90,90
                                     //rgb(90,90,90)
 Color_Active_Sector=52,58,62


### PR DESCRIPTION
Changed the TopSky TSA Danger Area Colour to:  `120,50,50` matching the R/D-areas colour in TopSkyMaps

![image](https://github.com/user-attachments/assets/e1d6f37a-f3dc-4154-9472-31a7177a85d9)
